### PR TITLE
Changed: The restart support is how handled by the parent class.

### DIFF
--- a/SIMDynPoroElasticity.h
+++ b/SIMDynPoroElasticity.h
@@ -48,8 +48,11 @@ public:
   }
 
   //! \brief Initializes the problem.
-  virtual bool init(const TimeStep&)
+  virtual bool init(const TimeStep&, bool withRF)
   {
+    if (!this->initSystem(Dim::opt.solver,1,1,0,withRF))
+      return false;
+
     dSim.initPrm();
     dSim.initSol(3);
 
@@ -93,41 +96,13 @@ public:
   //! \brief Returns a const reference to current solution vector.
   virtual const Vector& getSolution(int i) const { return dSim.getSolution(i); }
 
-  //! \brief Serialize internal state for restarting purposes.
-  //! \param data Container for serialized data
-  bool serialize(DataExporter::SerializeData& data)
-  {
-#ifdef HAS_CEREAL
-    std::ostringstream str;
-    cereal::BinaryOutputArchive ar(str);
-    for (size_t i = 0; i < 3; ++i)
-      ar(dSim.getSolution(i));
-    data.insert(std::make_pair(this->getName(), str.str()));
-    return true;
-#else
-    return false;
-#endif
-  }
-
-  //! \brief Set internal state from a serialized state.
-  //! \param data Container for serialized data
-  bool deSerialize(const DataExporter::SerializeData& data)
-  {
-#ifdef HAS_CEREAL
-    std::stringstream str;
-    auto it = data.find(this->getName());
-    if (it != data.end()) {
-      str << it->second;
-      cereal::BinaryInputArchive ar(str);
-      for (size_t i = 0; i < 3; ++i)
-        ar(const_cast<Vector&>(dSim.getSolution(i)));
-      return true;
-    }
-#endif
-    return false;
-  }
+  //! \brief Returns a const reference to the solution vectors.
+  virtual const Vectors& getSolutions() const { return dSim.getSolutions(); }
 
 protected:
+  //! \brief Returns a reference to the solution vectors (for assignment).
+  virtual Vectors& theSolutions() { return dSim.theSolutions(); }
+
   using SIMPoroElasticity<Dim>::parse;
   //! \brief Parses a data section from an XML element.
   virtual bool parse(const TiXmlElement* elem)

--- a/Test/SoilColumn3D.vreg
+++ b/Test/SoilColumn3D.vreg
@@ -8,18 +8,6 @@ Step 1
     Scalar: 'u_y'
     Scalar: 'u_z'
     Scalar: 'p^w'
-    Scalar: 'eps_x'
-    Scalar: 'eps_y'
-    Scalar: 'eps_z'
-    Scalar: 'eps_yz'
-    Scalar: 'eps_xz'
-    Scalar: 'eps_xy'
-    Scalar: 'sig_x'
-    Scalar: 'sig_y'
-    Scalar: 'sig_z'
-    Scalar: 'sig_yz'
-    Scalar: 'sig_xz'
-    Scalar: 'sig_xy'
     Vector: 'u'
 Step 2
   Element block 1

--- a/main.C
+++ b/main.C
@@ -51,12 +51,12 @@ template<class Dim, class Sim> int runSimulator (char* infile)
   if (!model.preprocess())
     return 2;
 
-  // Initialize the linear solvers, include assembly of reaction forces
-  if (!model.initSystem(model.opt.solver,1,1,0,true))
+  // Initialize the linear solvers and solution vectors,
+  // include assembly of reaction forces
+  if (!model.init(TimeStep(),true))
     return 2;
 
-  // Initialize the solution vectors, load initial conditions unless a restart
-  model.init(TimeStep());
+  // Load initial conditions unless a restart
   if (model.opt.restartFile.empty())
     model.setInitialConditions();
   else if (solver.restart(model.opt.restartFile,model.opt.restartStep) < 0)


### PR DESCRIPTION
Notice that the secondary solution is no longer calculated
for the initial configuration, due to the setMode(SIM::INIT) call.

Downstream of OPM/IFEM#282