### PR TITLE
Fixed: Account for time-dependent Dirichlet conditions.

### DIFF
--- a/PoroElastic/SIMPoroElasticity.h
+++ b/PoroElastic/SIMPoroElasticity.h
@@ -49,10 +49,6 @@ public:
   //! \brief Computes the solution for the current time step.
   virtual bool solveStep(TimeStep& tp)
   {
-    if (Dim::msgLevel >= 0)
-      IFEM::cout <<"\n  step = "<< tp.step
-                 <<"  time = "<< tp.time.t << std::endl;
-
     this->setMode(SIM::STATIC);
     this->setQuadratureRule(Dim::opt.nGauss[0],true);
     if (!this->assembleSystem(tp.time,SIMsolution::solution))

--- a/SIMStatPoroElasticity.h
+++ b/SIMStatPoroElasticity.h
@@ -1,0 +1,53 @@
+// $Id$
+//==============================================================================
+//!
+//! \file SIMStatPoroElasticity.h
+//!
+//! \date Sep 10 2018
+//!
+//! \author Knut Morten Okstad / SINTEF
+//!
+//! \brief Static simulation driver for poroelasticity problems.
+//!
+//==============================================================================
+
+#ifndef _SIM_STAT_PORO_ELASTICITY_H_
+#define _SIM_STAT_PORO_ELASTICITY_H_
+
+#include "SIMPoroElasticity.h"
+
+
+/*!
+  \brief Driver class for quasi-static poroelasticity problems.
+*/
+
+template<class Dim> class SIMStatPoroElasticity : public SIMPoroElasticity<Dim>
+{
+public:
+  //! \brief Default constructor.
+  SIMStatPoroElasticity() {}
+
+  //! \brief Constructor for mixed problems.
+  explicit SIMStatPoroElasticity(const std::vector<unsigned char>& flds)
+    : SIMPoroElasticity<Dim>(flds) {}
+
+  //! \brief Empty destructor.
+  virtual ~SIMStatPoroElasticity() {}
+
+  //! \brief Computes the solution for the current load step.
+  virtual bool solveStep(TimeStep& tp)
+  {
+    this->printStep(tp.step,tp.time);
+    if (!this->updateDirichlet(tp.time.t,&this->getSolution()))
+      return false;
+
+    double oldtol = utl::zero_print_tol;
+    utl::zero_print_tol = 1.0e-8;
+    bool ok = this->SIMPoroElasticity<Dim>::solveStep(tp);
+    utl::zero_print_tol = oldtol;
+
+    return ok;
+  }
+};
+
+#endif

--- a/Test/OGSBenchmark1D-LR.reg
+++ b/Test/OGSBenchmark1D-LR.reg
@@ -18,12 +18,12 @@ Number of dofs        261
 Number of D-dofs      192
 Number of P-dofs      69
 Number of unknowns    204
-  step = 1  time = 3.33
+  step=1  time=3.33
   Primary solution summary: L2-norm            : 0.000700444
                    Pressure L2-norm            : 0.00300726
                             Max Y-displacement : 0.00316079
                             Max pressure       : 0.00333116
-  step = 2  time = 6.66
+  step=2  time=6.66
   Primary solution summary: L2-norm            : 0.0011574
                    Pressure L2-norm            : 0.00288062
                             Max Y-displacement : 0.004741

--- a/Test/OGSBenchmark1D-nonmixed.reg
+++ b/Test/OGSBenchmark1D-nonmixed.reg
@@ -15,11 +15,11 @@ Number of elements    21
 Number of nodes       69
 Number of dofs        207
 Number of unknowns    154
-  step = 1  time = 3.33
+  step=1  time=3.33
   Primary solution summary: L2-norm            : 0.00181835
                             Max Y-displacement : 0.0031607
                             Max pressure       : 0.00333116
-  step = 2  time = 6.66
+  step=2  time=6.66
   Primary solution summary: L2-norm            : 0.00189024
                             Max Y-displacement : 0.00474104
                             Max pressure       : 0.00332878

--- a/Test/OGSBenchmark1D.reg
+++ b/Test/OGSBenchmark1D.reg
@@ -18,12 +18,12 @@ Number of dofs        261
 Number of D-dofs      192
 Number of P-dofs      69
 Number of unknowns    204
-  step = 1  time = 3.33
+  step=1  time=3.33
   Primary solution summary: L2-norm            : 0.000700444
                    Pressure L2-norm            : 0.00300726
                             Max Y-displacement : 0.00316079
                             Max pressure       : 0.00333116
-  step = 2  time = 6.66
+  step=2  time=6.66
   Primary solution summary: L2-norm            : 0.0011574
                    Pressure L2-norm            : 0.00288062
                             Max Y-displacement : 0.004741

--- a/Test/Plaxis1DVerif-LR.reg
+++ b/Test/Plaxis1DVerif-LR.reg
@@ -18,12 +18,12 @@ Number of dofs        409
 Number of D-dofs      288
 Number of P-dofs      121
 Number of unknowns    352
-  step = 1  time = 8475.82
+  step=1  time=8475.82
   Primary solution summary: L2-norm            : 0.0248471
                    Pressure L2-norm            : 0.0894779
                             Max Y-displacement : 0.10011
                             Max pressure       : 0.099991
-  step = 2  time = 16951.6
+  step=2  time=16951.6
   Primary solution summary: L2-norm            : 0.0406314
                    Pressure L2-norm            : 0.0859184
                             Max Y-displacement : 0.149947

--- a/Test/Plaxis1DVerif-nonmixed.reg
+++ b/Test/Plaxis1DVerif-nonmixed.reg
@@ -15,11 +15,11 @@ Number of elements    81
 Number of nodes       121
 Number of dofs        363
 Number of unknowns    310
-  step = 1  time = 8475.82
+  step=1  time=8475.82
   Primary solution summary: L2-norm            : 0.0552476
                             Max Y-displacement : 0.1
                             Max pressure       : 0.0999912
-  step = 2  time = 16951.6
+  step=2  time=16951.6
   Primary solution summary: L2-norm            : 0.0589531
                             Max Y-displacement : 0.15
                             Max pressure       : 0.0999451

--- a/Test/Plaxis1DVerif.reg
+++ b/Test/Plaxis1DVerif.reg
@@ -18,12 +18,12 @@ Number of dofs        409
 Number of D-dofs      288
 Number of P-dofs      121
 Number of unknowns    352
-  step = 1  time = 8475.82
+  step=1  time=8475.82
   Primary solution summary: L2-norm            : 0.0248471
                    Pressure L2-norm            : 0.0894779
                             Max Y-displacement : 0.10011
                             Max pressure       : 0.099991
-  step = 2  time = 16951.6
+  step=2  time=16951.6
   Primary solution summary: L2-norm            : 0.0406314
                    Pressure L2-norm            : 0.0859184
                             Max Y-displacement : 0.149947

--- a/Test/SoilColumn3D-nonmixed.reg
+++ b/Test/SoilColumn3D-nonmixed.reg
@@ -21,11 +21,11 @@ Number of elements    216
 Number of nodes       343
 Number of dofs        1372
 Number of unknowns    888
-  step = 1  time = 1200.2
+  step=1  time=1200.2
   Primary solution summary: L2-norm            : 0.00016794
                             Max Y-displacement : 0.00038676
                             Max pressure       : 0.000350497
-  step = 2  time = 2400.2
+  step=2  time=2400.2
   Primary solution summary: L2-norm            : 0.000161666
                             Max Y-displacement : 0.00051738
                             Max pressure       : 0.000166088

--- a/Test/SoilColumn3D.reg
+++ b/Test/SoilColumn3D.reg
@@ -23,12 +23,12 @@ Number of dofs        1879
 Number of D-dofs      1536
 Number of P-dofs      343
 Number of unknowns    1246
-  step = 1  time = 1200.2
+  step=1  time=1200.2
   Primary solution summary: L2-norm            : 0.000125749
                    Pressure L2-norm            : 0.000259295
                             Max Y-displacement : 0.000387386
                             Max pressure       : 0.000349614
-  step = 2  time = 2400.4
+  step=2  time=2400.4
   Primary solution summary: L2-norm            : 0.000176973
                    Pressure L2-norm            : 0.00011852
                             Max Y-displacement : 0.000517315


### PR DESCRIPTION
Added: Command-line option -stopTime overriding the input file setting.

Needed to facilitate comparison with FractureDynamics application in linear poro-elastic mode (-lstatic -poro -nocrack).