### PR TITLE
Linear static fix

### DIFF
--- a/SIMStatPoroElasticity.h
+++ b/SIMStatPoroElasticity.h
@@ -38,7 +38,9 @@ public:
   virtual bool solveStep(TimeStep& tp)
   {
     this->printStep(tp.step,tp.time);
-    if (!this->updateDirichlet(tp.time.t,&this->getSolution()))
+
+    Vector empty;
+    if (!this->updateDirichlet(tp.time.t,&empty))
       return false;
 
     double oldtol = utl::zero_print_tol;

--- a/Test/OGSBenchmark1D-LR.reg
+++ b/Test/OGSBenchmark1D-LR.reg
@@ -1,4 +1,4 @@
-OGSBenchmark1D.xinp -2D -mixed full -LR
+OGSBenchmark1D.xinp -2D -mixed-full -LR
 
 	Topology sets: Bottom (1,3,1D)
 	               Top (1,4,1D)

--- a/Test/OGSBenchmark1D.reg
+++ b/Test/OGSBenchmark1D.reg
@@ -1,4 +1,4 @@
-OGSBenchmark1D.xinp -2D -mixed full
+OGSBenchmark1D.xinp -2D -mixed-full
 
 	Topology sets: Bottom (1,3,1D)
 	               Top (1,4,1D)

--- a/Test/Plaxis1DVerif-LR.reg
+++ b/Test/Plaxis1DVerif-LR.reg
@@ -1,4 +1,4 @@
-Plaxis1DVerif.xinp -2D -mixed full -LR
+Plaxis1DVerif.xinp -2D -mixed-full -LR
 
 	Topology sets: Bottom (1,3,1D)
 	               Top (1,4,1D)

--- a/Test/Plaxis1DVerif.reg
+++ b/Test/Plaxis1DVerif.reg
@@ -1,4 +1,4 @@
-Plaxis1DVerif.xinp -2D -mixed full
+Plaxis1DVerif.xinp -2D -mixed-full
 
 	Topology sets: Bottom (1,3,1D)
 	               Top (1,4,1D)

--- a/Test/SoilColumn3D.reg
+++ b/Test/SoilColumn3D.reg
@@ -1,4 +1,4 @@
-SoilColumn3D.xinp -mixed full
+SoilColumn3D.xinp -mixed-full
 
 	Length in X = 0.001
 	Length in Y = 0.008

--- a/Test/Terzhagi-restart.reg
+++ b/Test/Terzhagi-restart.reg
@@ -1,4 +1,4 @@
-Terzhagi.xinp -2D -mixed full -dyn
+Terzhagi.xinp -2D -mixed-full -dyn
 
 Input file: Terzhagi.xinp
 Equation solver: 2

--- a/Test/Terzhagi.reg
+++ b/Test/Terzhagi.reg
@@ -1,4 +1,4 @@
-Terzhagi.xinp -2D -mixed full -dyn
+Terzhagi.xinp -2D -mixed-full -dyn
 
 Input file: Terzhagi.xinp
 Equation solver: 2

--- a/main.C
+++ b/main.C
@@ -134,12 +134,10 @@ int main (int argc, char** argv)
       ; // ignore the obsolete option
     else if (!strcmp(argv[i],"-2D"))
       twoD = Elastic::planeStrain = true;
-    else if (!strcmp(argv[i],"-mixed")) {
+    else if (!strcmp(argv[i],"-mixed-full"))
+      ASMmxBase::Type = ASMmxBase::FULL_CONT_RAISE_BASIS1;
+    else if (!strncmp(argv[i],"-mixed",6))
       ASMmxBase::Type = ASMmxBase::REDUCED_CONT_RAISE_BASIS1;
-      if (i < argc-1 && argv[i+1][0] != '-')
-        if (strcmp(argv[++i],"full") == 0)
-          ASMmxBase::Type = ASMmxBase::FULL_CONT_RAISE_BASIS1;
-    }
     else if (!strcmp(argv[i],"-dyn2"))
       integrator = 2;
     else if (!strncmp(argv[i],"-dyn",4))


### PR DESCRIPTION
This a fixup to #28 which was merged a bit early..

Accounting for the fact that the linear static solve option does not solve incrementally,
but for the total displacement state at each load step.

Also, replaced the -mixed full by -mixed-full, mostly to simplify the command-line option parsing.