### PR TITLE
Scaling fix

### DIFF
--- a/PoroElastic/PoroElasticity.h
+++ b/PoroElastic/PoroElasticity.h
@@ -73,13 +73,16 @@ protected:
   class Mats : public BlockElmMats
   {
   public:
-    //! \brief Default constructor.
+    //! \brief The constructor initializes the block sub-matrices.
     //! \param[in] ndof_displ Number of dofs in displacement
     //! \param[in] ndof_press Number of dofs in pressure
     //! \param[in] neumann Whether or not we are assembling Neumann BCs
     //! \param[in] dynamic Option for dynamic analysis
     //! (0: static analysis, 1: allocate M, 2: allocate M and D)
-    Mats(size_t ndof_displ, size_t ndof_press, bool neumann, char dynamic, int nbasis, int nsd);
+    //! \param[in] nbasis Number of different bases
+    //! \param[in] nsd Number of space dimensions
+    Mats(size_t ndof_displ, size_t ndof_press, bool neumann, char dynamic,
+         int nbasis, int nsd);
     //! \brief Empty destructor.
     virtual ~Mats() {}
 
@@ -235,8 +238,10 @@ public:
   //! \param[in] mode The solution mode to use
   virtual void setMode(SIM::SolutionMode mode);
 
-  //! \brief Returns the scaling factor at given location.
-  double getScaling(const Vec3& X, double dt = 0.0) const;
+  //! \brief Initializes the scaling factor.
+  virtual bool init(const TimeDomain& time);
+  //! \brief Returns the scaling factor.
+  double getScaling() const { return scl; }
 
   //! \brief Returns a local integral contribution object for the given element.
   //! \param[in] nen Number of nodes on element for each basis
@@ -361,18 +366,19 @@ protected:
 private:
   //! \brief Computes the coupling matrix for a quadrature point.
   bool evalCouplingMatrix(Matrix& mx, const Matrix& B, const Vector& N,
-                          double scl) const;
+                          double scale) const;
 
   //! \brief Computes the compressibility matrix for a quadrature point.
-  bool evalCompressibilityMatrix(Matrix& mx, const Vector& N, double scl) const;
+  bool evalCompressibilityMatrix(Matrix& mx, const Vector& N,
+                                 double scale) const;
 
   //! \brief Computes the permeability matrix for a quadrature point.
   void evalPermeabilityMatrix(Matrix& mx, const Matrix& dNdX,
-                              const SymmTensor& K, double scl) const;
+                              const SymmTensor& K, double scale) const;
 
   //! \brief Computes the dynamic coupling matrix for a quadrature point.
   void evalDynCouplingMatrix(Matrix& mx, const Vector& Nu, const Matrix& dNpdx,
-                             const SymmTensor& K, double scl) const;
+                             const SymmTensor& K, double scale) const;
 
 protected:
   //! \brief Computes the elasticity matrices for a quadrature point.
@@ -395,7 +401,7 @@ protected:
                                       const Vec3& X) const;
 
 private:
-  double sc; //!< Scaling factor
+  double scl; //!< Scaling factor
 
   bool calculateEnergy; //!< If \e true, perform energy norm calculation
   bool useDynCoupling;  //!< If \e true, include the dynamic coupling matrix

--- a/SIMDynPoroElasticity.h
+++ b/SIMDynPoroElasticity.h
@@ -48,7 +48,7 @@ public:
   }
 
   //! \brief Initializes the problem.
-  virtual bool init(const TimeStep&, bool withRF)
+  virtual bool init(const TimeStep& tp, bool withRF)
   {
     if (!this->initSystem(Dim::opt.solver,1,1,0,withRF))
       return false;
@@ -56,7 +56,7 @@ public:
     dSim.initPrm();
     dSim.initSol(3);
 
-    bool ok = this->setMode(SIM::INIT);
+    bool ok = this->setMode(SIM::INIT) && this->getIntegrand()->init(tp.time);
     this->setQuadratureRule(Dim::opt.nGauss[0],true);
     return ok;
   }

--- a/SIMStatPoroElasticity.h
+++ b/SIMStatPoroElasticity.h
@@ -38,7 +38,9 @@ public:
   virtual bool solveStep(TimeStep& tp)
   {
     this->printStep(tp.step,tp.time);
-    if (!this->updateDirichlet(tp.time.t,&this->getSolution()))
+
+    Vector empty;
+    if (!this->updateDirichlet(tp.time.t,&empty))
       return false;
 
     double oldtol = utl::zero_print_tol;

--- a/Test/OGSBenchmark1D-LR.reg
+++ b/Test/OGSBenchmark1D-LR.reg
@@ -1,4 +1,4 @@
-OGSBenchmark1D.xinp -2D -mixed full -LR
+OGSBenchmark1D.xinp -2D -mixed-full -LR
 
 	Topology sets: Bottom (1,3,1D)
 	               Top (1,4,1D)

--- a/Test/OGSBenchmark1D.reg
+++ b/Test/OGSBenchmark1D.reg
@@ -1,4 +1,4 @@
-OGSBenchmark1D.xinp -2D -mixed full
+OGSBenchmark1D.xinp -2D -mixed-full
 
 	Topology sets: Bottom (1,3,1D)
 	               Top (1,4,1D)

--- a/Test/Plaxis1DVerif-LR.reg
+++ b/Test/Plaxis1DVerif-LR.reg
@@ -1,4 +1,4 @@
-Plaxis1DVerif.xinp -2D -mixed full -LR
+Plaxis1DVerif.xinp -2D -mixed-full -LR
 
 	Topology sets: Bottom (1,3,1D)
 	               Top (1,4,1D)

--- a/Test/Plaxis1DVerif.reg
+++ b/Test/Plaxis1DVerif.reg
@@ -1,4 +1,4 @@
-Plaxis1DVerif.xinp -2D -mixed full
+Plaxis1DVerif.xinp -2D -mixed-full
 
 	Topology sets: Bottom (1,3,1D)
 	               Top (1,4,1D)

--- a/Test/SoilColumn3D-nonmixed.reg
+++ b/Test/SoilColumn3D-nonmixed.reg
@@ -25,7 +25,7 @@ Number of unknowns    888
   Primary solution summary: L2-norm            : 0.00016794
                             Max Y-displacement : 0.00038676
                             Max pressure       : 0.000350497
-  step=2  time=2400.2
-  Primary solution summary: L2-norm            : 0.000161666
-                            Max Y-displacement : 0.00051738
-                            Max pressure       : 0.000166088
+  step=2  time=2400.4
+  Primary solution summary: L2-norm            : 0.000161669
+                            Max Y-displacement : 0.00051739
+                            Max pressure       : 0.000166086

--- a/Test/SoilColumn3D-nonmixed.xinp
+++ b/Test/SoilColumn3D-nonmixed.xinp
@@ -45,6 +45,6 @@
                perm="0.00000000000001962 0.00000000000001962 0.0"/>
   </poroelasticity>
 
-  <timestepping start="0" end="2400.2" dt="1200.2"/>
+  <timestepping start="0" end="2400.4" dt="1200.2"/>
 
 </simulation>

--- a/Test/SoilColumn3D.reg
+++ b/Test/SoilColumn3D.reg
@@ -1,4 +1,4 @@
-SoilColumn3D.xinp -mixed full
+SoilColumn3D.xinp -mixed-full
 
 	Length in X = 0.001
 	Length in Y = 0.008

--- a/Test/Terzhagi-restart.reg
+++ b/Test/Terzhagi-restart.reg
@@ -1,4 +1,4 @@
-Terzhagi.xinp -2D -mixed full -dyn
+Terzhagi.xinp -2D -mixed-full -dyn
 
 Input file: Terzhagi.xinp
 Equation solver: 2

--- a/Test/Terzhagi.reg
+++ b/Test/Terzhagi.reg
@@ -1,4 +1,4 @@
-Terzhagi.xinp -2D -mixed full -dyn
+Terzhagi.xinp -2D -mixed-full -dyn
 
 Input file: Terzhagi.xinp
 Equation solver: 2

--- a/Test/TestSIMPoroElasticity.C
+++ b/Test/TestSIMPoroElasticity.C
@@ -12,6 +12,7 @@
 
 #include "SIMPoroElasticity.h"
 #include "SIM2D.h"
+#include "TimeStep.h"
 
 #include "gtest/gtest.h"
 
@@ -20,6 +21,7 @@ TEST(TestSIMPoroElasticity, Parse)
 {
   SIMPoroElasticity<SIM2D> sim;
   ASSERT_TRUE(sim.read("Plaxis1DVerif.xinp"));
+  ASSERT_TRUE(sim.init(TimeStep()));
 
   const PoroElasticity* poro = static_cast<const PoroElasticity*>(sim.getProblem());
 
@@ -27,5 +29,5 @@ TEST(TestSIMPoroElasticity, Parse)
   ASSERT_FLOAT_EQ(grav.x,0.0);
   ASSERT_FLOAT_EQ(grav.y,9.81);
   ASSERT_FLOAT_EQ(grav.z,0.0);
-  ASSERT_FLOAT_EQ(poro->getScaling(Vec3()),0.0);
+  ASSERT_NEAR(poro->getScaling(),920642222.3,0.1);
 }

--- a/main.C
+++ b/main.C
@@ -75,7 +75,7 @@ template<class Dim, class Sim> int runSimulator (char* infile, double stopTime)
 
   // Initialize the linear solvers and solution vectors,
   // include assembly of reaction forces
-  if (!model.init(TimeStep(),true))
+  if (!model.init(solver.getTimePrm(),true))
     return 2;
 
   // Load initial conditions unless a restart

--- a/main.C
+++ b/main.C
@@ -134,12 +134,10 @@ int main (int argc, char** argv)
       ; // ignore the obsolete option
     else if (!strcmp(argv[i],"-2D"))
       twoD = Elastic::planeStrain = true;
-    else if (!strcmp(argv[i],"-mixed")) {
+    else if (!strcmp(argv[i],"-mixed-full"))
+      ASMmxBase::Type = ASMmxBase::FULL_CONT_RAISE_BASIS1;
+    else if (!strncmp(argv[i],"-mixed",6))
       ASMmxBase::Type = ASMmxBase::REDUCED_CONT_RAISE_BASIS1;
-      if (i < argc-1 && argv[i+1][0] != '-')
-        if (strcmp(argv[++i],"full") == 0)
-          ASMmxBase::Type = ASMmxBase::FULL_CONT_RAISE_BASIS1;
-    }
     else if (!strcmp(argv[i],"-dyn2"))
       integrator = 2;
     else if (!strncmp(argv[i],"-dyn",4))


### PR DESCRIPTION
This fixes #29.

It computes the (should be constant) scaling factor during the initialization based on the first time step size. The first two commits are also in #31.

Requires OPM/IFEM-Elasticity#59