### PR TITLE
The great unit confusion

### DIFF
--- a/PoroElastic/PoroElasticity.C
+++ b/PoroElastic/PoroElasticity.C
@@ -139,7 +139,7 @@ bool PoroElasticity::init (const TimeDomain& time)
       Vec3 perm = pmat->getPermeability(X);
       for (int d = 1; d <= nsd; d++)
         cars.perm += perm(d);
-      cars.perm /= pmat->getFluidDensity(X) * gravity.length() * nsd;
+      cars.perm /= pmat->getViscosity(X) * nsd;
       IFEM::cout << "\tComputed characteristic permeability = " << cars.perm << std::endl;
     }
   }
@@ -377,7 +377,7 @@ bool PoroElasticity::evalInt (LocalIntegral& elmInt,
     return false;
 
   // Evaluate other material parameters
-  double rhog  = pmat->getFluidDensity(X) * gravity.length();
+  double visc  = pmat->getViscosity(X);
   double poro  = pmat->getPorosity(X);
   double alpha = pmat->getBiotCoeff(X);
   double Minv  = pmat->getBiotModulus(X,alpha,poro);
@@ -390,10 +390,10 @@ bool PoroElasticity::evalInt (LocalIntegral& elmInt,
 
   if (!elMat.A[up_D].empty())
     this->evalDynCouplingMatrix(elMat.A[up_D], fe.basis(1), fe.grad(2),
-                                Kperm, 1.0 / rhog * fe.detJxW);
+                                Kperm, 1.0 / visc * fe.detJxW);
 
   this->evalPermeabilityMatrix(elMat.A[pp_P], fe.grad(2),
-                               Kperm, 1.0 / rhog * fe.detJxW);
+                               Kperm, 1.0 / visc * fe.detJxW);
 
   if (!this->evalElasticityMatrices(elMat, Bmat, fe, X))
     return false;

--- a/PoroElastic/PoroMaterial.C
+++ b/PoroElastic/PoroMaterial.C
@@ -86,11 +86,10 @@ void PoroMaterial::parse (const TiXmlElement* elem)
 {
   propertyParse(Emod, elem, "E", "stiffness");
   propertyParse(nu, elem, "nu", "poisson");
-  if (utl::getAttribute(elem, "mu", Emod.constant))
-    Emod.constant *= 2.0 + 2.0*nu.constant;
 
   propertyParse(rhof, elem, "rhof", "fluiddensity");
   propertyParse(rhos, elem, "rhos", "soliddensity");
+  propertyParse(viscosity, elem, "mu", "viscosity");
 
   propertyParse(porosity, elem, "poro", "porosity");
   propertyParse(permeability, elem, "perm", "permeability");
@@ -152,6 +151,12 @@ double PoroMaterial::getMassDensity (const Vec3& X) const
 {
   double poro = porosity.evaluate(X);
   return rhos.evaluate(X)*(1.0-poro) + rhof.evaluate(X)*poro;
+}
+
+
+double PoroMaterial::getViscosity (const Vec3& X) const
+{
+  return viscosity.evaluate(X);
 }
 
 

--- a/PoroElastic/PoroMaterial.h
+++ b/PoroElastic/PoroMaterial.h
@@ -63,6 +63,8 @@ public:
   double getSolidDensity(const Vec3&) const;
   //! \brief Evaluates the mass density at current point.
   virtual double getMassDensity(const Vec3&) const;
+  //! \brief Returns the dynamic viscosity at current point.
+  double getViscosity(const Vec3& X) const;
   //! \brief Returns porosity at the current point.
   double getPorosity(const Vec3& X) const;
   //! \brief Returns permeability at the current point.
@@ -106,10 +108,11 @@ public:
                         const FiniteElement&, const Vec3& X) const;
 
 protected:
-  FuncConstPair<RealFunc> Emod; //!< Young's modulus
-  FuncConstPair<RealFunc> nu;   //!< Poisson's ratio
-  FuncConstPair<RealFunc> rhof; //!< Fluid density
-  FuncConstPair<RealFunc> rhos; //!< Solid density
+  FuncConstPair<RealFunc> Emod;         //!< Young's modulus
+  FuncConstPair<RealFunc> nu;           //!< Poisson's ratio
+  FuncConstPair<RealFunc> rhof;         //!< Fluid density
+  FuncConstPair<RealFunc> rhos;         //!< Solid density
+  FuncConstPair<RealFunc> viscosity;    //!< Dynamic viscosity
 
   FuncConstPair<RealFunc> porosity;     //!< Porosity
   FuncConstPair<VecFunc>  permeability; //!< Permeability

--- a/Test/OGSBenchmark1D-nonmixed.xinp
+++ b/Test/OGSBenchmark1D-nonmixed.xinp
@@ -31,7 +31,7 @@
   <poroelasticity>
     <isotropic poro="0.5" rhof="1000.0" rhos="2700.0"
                Kf="1e99" Ks="1e99" Ko="0" E="30000" nu="0.2"
-               perm="0.000981 0.000981 0.0"/>
+               perm="0.000981 0.000981 0.0" mu="9810" />
   </poroelasticity>
 
   <timestepping start="0" end="6.660" dt="3.330"/>

--- a/Test/OGSBenchmark1D.xinp
+++ b/Test/OGSBenchmark1D.xinp
@@ -31,7 +31,7 @@
   <poroelasticity>
     <isotropic poro="0.5" rhof="1000.0" rhos="2700.0"
                Kf="1e99" Ks="1e99" Ko="0" E="30000" nu="0.2"
-               perm="0.000981 0.000981 0.0"/>
+               perm="0.000981 0.000981 0.0" mu="9810" />
   </poroelasticity>
 
   <timestepping start="0" end="6.660" dt="3.330"/>

--- a/Test/Plaxis1DVerif-nondim.xinp
+++ b/Test/Plaxis1DVerif-nondim.xinp
@@ -30,7 +30,7 @@
   <!-- Problem-specific block !-->
   <poroelasticity>
     <isotropic E="1000000" nu="0.0" Minv="1e-10" alpha="1.0" rhof="1000.0" rhos="2700.0"
-               perm="0.0000000115741 0.0000000115741 0.0" />
+               perm="0.0000000115741 0.0000000115741 0.0" mu="9810" />
     <nondimensionalize />
   </poroelasticity>
 

--- a/Test/Plaxis1DVerif-nonmixed.xinp
+++ b/Test/Plaxis1DVerif-nonmixed.xinp
@@ -30,7 +30,7 @@
   <!-- Problem-specific block !-->
   <poroelasticity>
     <isotropic poro="0.5" E="1000000" nu="0.0" Kf="1e99" Ks="1e99" Ko="0"
-               rhof="1000.0" rhos="2700.0"
+               rhof="1000.0" rhos="2700.0" mu="9810"
                perm="0.0000000115741 0.0000000115741 0.0"/>
   </poroelasticity>
 

--- a/Test/Plaxis1DVerif.xinp
+++ b/Test/Plaxis1DVerif.xinp
@@ -30,7 +30,7 @@
   <!-- Problem-specific block !-->
   <poroelasticity>
     <isotropic poro="0.5" E="1000000" nu="0.0" Kf="1e99" Ks="1e99" Ko="0"
-               rhof="1000.0" rhos="2700.0"
+               rhof="1000.0" rhos="2700.0" mu="9810"
                perm="0.0000000115741 0.0000000115741 0.0"/>
   </poroelasticity>
 

--- a/Test/SoilColumn3D-nonmixed.xinp
+++ b/Test/SoilColumn3D-nonmixed.xinp
@@ -41,7 +41,7 @@
   <!-- Problem-specific block !-->
   <poroelasticity>
     <isotropic poro="0.5" E="6000000000" nu="0.4" Kf="3e99" Ks="3e99" Ko="0"
-               rhof="1000.0" rhos="2700.0"
+               rhof="1000.0" rhos="2700.0" mu="9810"
                perm="0.00000000000001962 0.00000000000001962 0.0"/>
   </poroelasticity>
 

--- a/Test/SoilColumn3D.xinp
+++ b/Test/SoilColumn3D.xinp
@@ -41,7 +41,7 @@
   <!-- Problem-specific block !-->
   <poroelasticity>
     <isotropic poro="0.5" E="6000000000" nu="0.4" Kf="3e99" Ks="3e99" Ko="0"
-               rhof="1000.0" rhos="2700.0"
+               rhof="1000.0" rhos="2700.0" mu="9810"
                perm="0.00000000000001962 0.00000000000001962 0.0"/>
   </poroelasticity>
 

--- a/Test/Terzhagi-nondim.xinp
+++ b/Test/Terzhagi-nondim.xinp
@@ -29,7 +29,7 @@
   <!-- Problem-specific block !-->
   <poroelasticity>
     <isotropic E="1e1" nu="0.4" poro="0.5" alpha="1.0" Minv="0.0"
-               rhof="1.0" rhos="1.0" perm="1e-3 1e-3"/>
+               rhof="1.0" rhos="1.0" perm="1e-3 1e-3" mu="9.81" />
     <useDynCoupling/>
     <nondimensionalize />
   </poroelasticity>

--- a/Test/Terzhagi.xinp
+++ b/Test/Terzhagi.xinp
@@ -29,7 +29,7 @@
   <!-- Problem-specific block !-->
   <poroelasticity>
     <isotropic E="1.0" nu="0.4" poro="0.5" alpha="1.0" Minv="0.0"
-               rhof="1.0" rhos="1.0" perm="1.0 1.0"/>
+               rhof="1.0" rhos="1.0" perm="1.0 1.0" mu="9.81" />
     <useDynCoupling/>
     <calcEnergy/>
     <anasol type="terzhagi-stationary" height="1.0" load="1.0"/>

--- a/Test/TestPoroMaterial.C
+++ b/Test/TestPoroMaterial.C
@@ -33,6 +33,7 @@ TEST(TestPoroMaterial, Parse)
   Vec3 X;
   ASSERT_FLOAT_EQ(mat.getFluidDensity(X), 1000.0);
   ASSERT_FLOAT_EQ(mat.getSolidDensity(X), 2700.0);
+  ASSERT_FLOAT_EQ(mat.getViscosity(X), 9810.0);
   ASSERT_FLOAT_EQ(mat.getPorosity(X), 0.5);
   ASSERT_FLOAT_EQ(mat.getStiffness(X), 1000000.0);
   ASSERT_FLOAT_EQ(mat.getPoisson(X), 0.0);

--- a/Test/VolFlux.xinp
+++ b/Test/VolFlux.xinp
@@ -12,7 +12,7 @@
   </geometry>
 
   <poroelasticity>
-    <isotropic poro="0.5" E="1" nu="0.2" alpha="1.0" Minv="1" perm="1 1 0" rhof="1000.0" rhos="2700.0" />
+    <isotropic poro="0.5" E="1" nu="0.2" alpha="1.0" Minv="1" perm="1 1 0" rhof="1000.0" rhos="2700.0" mu="9810" />
     <volumeflux type="expression">
       xmin=1.8; xmax=2.2; ymin=1.8; ymax=2.2; flow=1e-4;
       if(below(x,xmax),if(above(x,xmin),if(below(y,ymax),if(above(y,ymin),flow,0.0),0.0),0.0),0.0)


### PR DESCRIPTION
So, the proportionality constant in Darcy's law is K / gamma, or equivalently kappa / mu. Here, K is the hydraulic conductivity [m/s], gamma is the unit weight of the fluid [N/m^3], kappa is the permeability [m^2] and mu is the dynamic viscosity [Pa s].

Until now our input files have confusingly been giving hydraulic conductivity as the input called "perm". So long as the resulting proportionality constant is the same, this isn't really a problem. However, when the permeability is modified in OpenFrac, it matters. For water, gamma/mu is in the region of 10^7, so OpenFrac sees a material that is much more permeable than it really is, thereby requiring very large cracks before the crack can support a flow that is greater than the porous medium.

This fixes the issue by making the input files provide the *actual* permeability. In addition to getting OpenFrac to work, I find this form more natural because it separates strictly parameters for the porous medium and the fluid.

To get the proportionality constant right, a new material parameter is added for the dynamic viscosity. In the tests I've left *perm* unchanged and set *mu* to 9.81 times the fluid density, so that in theory the test input files now describe very viscous fluids in very permeable materials.