### PR TITLE
Changed: Reduce code duplication.

### DIFF
--- a/PoroElastic/SIMPoroElasticity.C
+++ b/PoroElastic/SIMPoroElasticity.C
@@ -16,20 +16,15 @@
 #include "PoroMaterial.h"
 
 
-template<> bool SIMPoroEl2D::parseDimSpecific (const TiXmlElement* child)
+template<> bool SIMPoroEl2D::parseDimSpecific (const TiXmlElement* elem)
 {
-  if (strcasecmp(child->Value(),"anasol"))
-    return false;
-  else if (SIM2D::mySol)
-    return true;
-
   std::string type;
-  utl::getAttribute(child,"type",type,true);
+  utl::getAttribute(elem,"type",type,true);
   if (type == "terzhagi")
   {
     double height = 1.0, load = 1.0;
-    utl::getAttribute(child,"height",height);
-    utl::getAttribute(child,"load",load);
+    utl::getAttribute(elem,"height",height);
+    utl::getAttribute(elem,"load",load);
     IFEM::cout <<"\tAnalytical solution: Terzhagi, height = "<< height
                <<" load = "<< load << std::endl;
     Elasticity* elp = this->getIntegrand();
@@ -40,7 +35,7 @@ template<> bool SIMPoroEl2D::parseDimSpecific (const TiXmlElement* child)
   else if (type == "terzhagi-stationary")
   {
     double load = 1.0;
-    utl::getAttribute(child,"load",load);
+    utl::getAttribute(elem,"load",load);
     IFEM::cout <<"\tAnalytical solution: Terzhagi (stationary),"
                <<" load = "<< load << std::endl;
     Elasticity* elp = this->getIntegrand();
@@ -49,24 +44,7 @@ template<> bool SIMPoroEl2D::parseDimSpecific (const TiXmlElement* child)
                               new StationaryTerzhagiDisplacement(pmat,load));
   }
   else
-  {
-    IFEM::cout <<"\tAnalytical solution: Expression"<< std::endl;
-    SIM2D::mySol = new AnaSol(child);
-  }
-
-  return true;
-}
-
-
-template<> bool SIMPoroEl3D::parseDimSpecific (const TiXmlElement* child)
-{
-  if (strcasecmp(child->Value(),"anasol"))
     return false;
-  else if (SIM3D::mySol)
-    return true;
-
-  IFEM::cout <<"\tAnalytical solution: Expression"<< std::endl;
-  SIM3D::mySol = new AnaSol(child);
 
   return true;
 }

--- a/PoroElastic/SIMPoroElasticity.h
+++ b/PoroElastic/SIMPoroElasticity.h
@@ -16,7 +16,6 @@
 
 #include "SIMElasticityWrap.h"
 #include "SIM2D.h"
-#include "SIM3D.h"
 #include "SAM.h"
 #include "PoroElasticity.h"
 #include "ASMmxBase.h"
@@ -191,9 +190,20 @@ protected:
     return this->SIMElasticityWrap<Dim>::parse(elem);
   }
 
-  using SIMElasticityWrap<Dim>::parseDimSpecific;
-  //! \brief Parses a dimension-specific data section from an XML element.
-  virtual bool parseDimSpecific(const TiXmlElement* elem);
+  using SIMElasticityWrap<Dim>::parseAnaSol;
+  //! \brief Parses the analytical solution from an XML element.
+  virtual bool parseAnaSol(const TiXmlElement* elem)
+  {
+    if (Dim::mySol || this->parseDimSpecific(elem))
+      return true;
+
+    IFEM::cout <<"\tAnalytical solution: Expression"<< std::endl;
+    Dim::mySol = new AnaSol(elem);
+    return true;
+  }
+
+  //! \brief Parses dimension-specific analytical solution from an XML element.
+  bool parseDimSpecific(const TiXmlElement*) { return false; }
 
 private:
   double scaleD; //!< Displacement DOF scaling in convergence checks
@@ -202,11 +212,8 @@ private:
 
 
 typedef SIMPoroElasticity<SIM2D> SIMPoroEl2D; //!< 2D specific driver
-typedef SIMPoroElasticity<SIM3D> SIMPoroEl3D; //!< 3D specific driver
 
 //! \brief Template specialization - 2D specific input parsing.
 template<> bool SIMPoroEl2D::parseDimSpecific(const TiXmlElement* elem);
-//! \brief Template specialization - 3D specific input parsing.
-template<> bool SIMPoroEl3D::parseDimSpecific(const TiXmlElement* elem);
 
 #endif


### PR DESCRIPTION
The parsing of analytical solution is now handled by the new parseAnaSol
method which is dimension independent, only the 2D-specific Terzagi solution
remains in the parseDimSpecific method.

Downstream of OPM/IFEM-Elasticity#102