### PR TITLE
fix constructor for FractureDynamics usage

### DIFF
--- a/PoroElastic/SIMPoroElasticity.C
+++ b/PoroElastic/SIMPoroElasticity.C
@@ -27,7 +27,7 @@
 
 
 template<class Dim>
-SIMPoroElasticity<Dim>::SIMPoroElasticity ()
+SIMPoroElasticity<Dim>::SIMPoroElasticity (const std::vector<unsigned char>&)
 {
   if (ASMmxBase::Type > ASMmxBase::NONE)
     Dim::nf = { Dim::dimension, 1 }; // mixed formulation

--- a/PoroElastic/SIMPoroElasticity.h
+++ b/PoroElastic/SIMPoroElasticity.h
@@ -25,7 +25,7 @@ template<class Dim> class SIMPoroElasticity : public SIMElasticityWrap<Dim>
 {
 public:
   //! \brief The default constructor sets the solution dimension for each basis.
-  SIMPoroElasticity();
+  explicit SIMPoroElasticity(const std::vector<unsigned char>& = {});
 
   //! \brief Empty destructor.
   virtual ~SIMPoroElasticity() {}


### PR DESCRIPTION
There's a constructor in SimDynElasticitiy passing fields. Since we now explicitly instance the template, this constructor is instanced for PoroElasticity so we need a param.