### PR TITLE
Changed: SIMElasticity::getIntegrand() now returns an ElasticBase pointer

### DIFF
--- a/PoroElastic/SIMPoroElasticity.C
+++ b/PoroElastic/SIMPoroElasticity.C
@@ -156,11 +156,12 @@ bool SIMPoroElasticity<Dim>::initNeumann (size_t propInd)
 
 
 template<class Dim>
-Elasticity* SIMPoroElasticity<Dim>::getIntegrand ()
+ElasticBase* SIMPoroElasticity<Dim>::getIntegrand ()
 {
   if (!Dim::myProblem)
     Dim::myProblem = new PoroElasticity(Dim::dimension, Dim::nf.size() > 1);
-  return static_cast<Elasticity*>(Dim::myProblem);
+
+  return static_cast<ElasticBase*>(Dim::myProblem);
 }
 
 
@@ -196,8 +197,8 @@ bool SIMPoroElasticity<Dim>::parseAnaSol (const tinyxml2::XMLElement* elem)
 
 
 //! \brief Template specialization - 2D specific input parsing.
-template<>
-bool SIMPoroElasticity<SIM2D>::parseDimSpecific (const tinyxml2::XMLElement* elem)
+template<> bool
+SIMPoroElasticity<SIM2D>::parseDimSpecific (const tinyxml2::XMLElement* elem)
 {
   std::string type;
   utl::getAttribute(elem,"type",type,true);
@@ -208,7 +209,7 @@ bool SIMPoroElasticity<SIM2D>::parseDimSpecific (const tinyxml2::XMLElement* ele
     utl::getAttribute(elem,"load",load);
     IFEM::cout <<"\tAnalytical solution: Terzhagi, height = "<< height
                <<" load = "<< load << std::endl;
-    Elasticity* elp = this->getIntegrand();
+    ElasticBase* elp = this->getIntegrand();
     PoroMaterial* pmat = static_cast<PoroMaterial*>(elp->getMaterial());
     double gacc = elp->getGravity().length();
     SIM2D::mySol = new AnaSol(new TerzhagiPressure(pmat,gacc,height,load));
@@ -219,7 +220,7 @@ bool SIMPoroElasticity<SIM2D>::parseDimSpecific (const tinyxml2::XMLElement* ele
     utl::getAttribute(elem,"load",load);
     IFEM::cout <<"\tAnalytical solution: Terzhagi (stationary),"
                <<" load = "<< load << std::endl;
-    Elasticity* elp = this->getIntegrand();
+    ElasticBase* elp = this->getIntegrand();
     PoroMaterial* pmat = static_cast<PoroMaterial*>(elp->getMaterial());
     SIM2D::mySol = new AnaSol(new ConstFunc(0.0), nullptr,
                               new StationaryTerzhagiDisplacement(pmat,load));

--- a/PoroElastic/SIMPoroElasticity.h
+++ b/PoroElastic/SIMPoroElasticity.h
@@ -43,11 +43,13 @@ public:
   //! \param[out] rNorm Residual norm of solution increment
   //! \param[out] dNorm Displacement norm of solution increment
   void iterationNorms(const Vector& u, const Vector& r,
-                      double& eNorm, double& rNorm, double& dNorm) const override;
+                      double& eNorm, double& rNorm,
+                      double& dNorm) const override;
 
   //! \brief Prints a summary of the calculated solution to std::cout.
   void printSolutionSummary(const Vector& solution, int = 0,
-                            const char* = nullptr, std::streamsize = 0) override;
+                            const char* = nullptr,
+                            std::streamsize = 0) override;
 
   //! \brief Computes energy norms on the converged solution.
   bool postSolve(TimeStep& tp);
@@ -57,7 +59,7 @@ public:
 
 protected:
   //! \brief Returns the actual integrand.
-  Elasticity* getIntegrand() override;
+  ElasticBase* getIntegrand() override;
 
   using SIMElasticityWrap<Dim>::parse;
   //! \brief Parses a data section from an XML element


### PR DESCRIPTION
Downstream of OPM/IFEM-Elasticity#159